### PR TITLE
remove es5 and es6 polyfills, they has been used in an oder version

### DIFF
--- a/examples/grape-input/index.html
+++ b/examples/grape-input/index.html
@@ -23,8 +23,6 @@
     </style>
   </head>
   <body>
-    <script src="../../node_modules/es5-shim/es5-shim.js"></script>
-    <script src="../../node_modules/es6-shim/es6-shim.js"></script>
     <script src="../../node_modules/document-register-element/build/document-register-element.max.js"></script>
     <script src="/build/grape-browser.js"></script>
     <script src="./data.js"></script>

--- a/package.json
+++ b/package.json
@@ -37,8 +37,6 @@
     "babel-loader": "^5.3.1",
     "custom-event-polyfill": "^0.2.1",
     "document-register-element": "^0.1.8",
-    "es5-shim": "^4.1.10",
-    "es6-shim": "^0.32.2",
     "eslint": "^1.9.0",
     "eslint-config-airbnb": "^1.0.0",
     "eslint-config-ubergrape": "^2.0.0",


### PR DESCRIPTION
Also currently for some reason es6 polyfill throws an error
